### PR TITLE
Raise IOError when TCPConnection.read(length) recieves no data.

### DIFF
--- a/mcstatus/protocol/connection.py
+++ b/mcstatus/protocol/connection.py
@@ -140,7 +140,10 @@ class TCPSocketConnection(Connection):
     def read(self, length):
         result = bytearray()
         while len(result) < length:
-            result.extend(self.socket.recv(length - len(result)))
+            new = self.socket.recv(length - len(result))
+            if len(new) == 0:
+                raise IOError("Server did not respond with any information!")
+            result.extend(new)
         return result
 
     def write(self, data):

--- a/mcstatus/tests/protocol/test_connection.py
+++ b/mcstatus/tests/protocol/test_connection.py
@@ -225,6 +225,12 @@ class TCPSocketConnectionTest(TestCase):
 
         self.assertEqual(self.connection.read(2), bytearray.fromhex("7FAA"))
 
+    def test_read_empty(self):
+        self.connection.socket.recv.return_value = bytearray.fromhex("")
+
+        with self.assertRaises(IOError):
+            self.connection.read(2)
+
     def test_write(self):
         self.connection.write(bytearray.fromhex("7FAA"))
 


### PR DESCRIPTION
This commit fixes #24 by simply checking whether the socket received any data at all. If it did not, an IOError is raised.
It might be that we should try to recieve multiple times before the IOError is raised, but this is not implemented in this commit as to avoid bloat.