### PR TITLE
Resolve DNS before sending packets

### DIFF
--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -62,9 +62,17 @@ class MinecraftServer:
 
     def query(self, retries=3):
         exception = None
+        host = self.host
+        try:
+            answers = dns.resolver.query(host, "A")
+            if len(answers):
+                answer = answers[0]
+                host = str(answer).rstrip(".")
+        except Exception as e:
+            pass
         for attempt in range(retries):
             try:
-                connection = UDPSocketConnection((self.host, self.port))
+                connection = UDPSocketConnection((host, self.port))
                 querier = ServerQuerier(connection)
                 querier.handshake()
                 return querier.read_query()


### PR DESCRIPTION
This fixes some servers with long DNS queries or slow resolution not getting UDP queries correctly.

This only matters for the UDP case as it'll resolve the DNS each time a packet is sent, spending extra time or receiving an invalid/different record each time. TCP methods (ping) don't have this issue since they maintain the connection opened (so only one DNS resolution is made).