### PR TITLE
Use setuptools to enable dependency checking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 import sys
 PY2 = sys.version_info[0] == 2
 


### PR DESCRIPTION
It turns out distutils cannot easily check for installed packages and makes
no effort to install missing packages. Setuptools on the other hand will
gladly do this for use.

This way situations like #33 cannot arise.
