### PR TITLE
Implicitly close sockets in destructor methods

### DIFF
--- a/mcstatus/protocol/connection.py
+++ b/mcstatus/protocol/connection.py
@@ -149,6 +149,9 @@ class TCPSocketConnection(Connection):
     def write(self, data):
         self.socket.send(data)
 
+    def __del__(self):
+        self.socket.close()
+
 
 class UDPSocketConnection(Connection):
     def __init__(self, addr, timeout=3):
@@ -176,3 +179,6 @@ class UDPSocketConnection(Connection):
         if isinstance(data, Connection):
             data = bytearray(data.flush())
         self.socket.sendto(data, self.addr)
+
+    def __del__(self):
+        self.socket.close()


### PR DESCRIPTION
TCP / UDP Sockets used in the Connection class dont get closed (so urllib3 was complaining).

Putting the .close() into __del__(self) will close it implicitly when Connection goes out of scope.

I'm not 100% sure if sockets got closed by GC before, but this cleans up the logfile when using mcstatus with bottlepy.
