### PR TITLE
Write the port as an unsigned short

### DIFF
--- a/mcstatus/pinger.py
+++ b/mcstatus/pinger.py
@@ -21,7 +21,7 @@ class ServerPinger:
         packet.write_varint(0)
         packet.write_varint(self.version)
         packet.write_utf(self.host)
-        packet.write_short(self.port)
+        packet.write_ushort(self.port)
         packet.write_varint(1)  # Intention to query status
 
         self.connection.write_buffer(packet)


### PR DESCRIPTION
According to [the protocol](http://wiki.vg/Protocol#Handshake), the port should be an unsigned short. I discovered this while trying to ping a server with port `44444`, which raised the following exception:
```
error: 'h' format requires -32768 <= number <= 32767
```
