### PR TITLE
Fix § character display

### DIFF
--- a/mcstatus/scripts/mcstatus.py
+++ b/mcstatus/scripts/mcstatus.py
@@ -57,14 +57,14 @@ def status():
     servers that are version 1.7 or higher.
     """
     response = server.status()
-    click.echo("version: v{} (protocol {})".format(response.version.name, response.version.protocol))
+    click.echo("version: v{} (protocol {})".format(response.version.name.encode("utf-8"), response.version.protocol))
     click.echo("description: \"{}\"".format(response.description))
     click.echo(
         "players: {}/{} {}".format(
             response.players.online,
             response.players.max,
             [
-                "{} ({})".format(player.name, player.id)
+                "{} ({})".format(player.name.encode("utf-8"), player.id)
                 for player in response.players.sample
             ] if response.players.sample is not None else "No players online"
         )
@@ -114,7 +114,7 @@ def query():
     click.echo("host: {}:{}".format(response.raw['hostip'], response.raw['hostport']))
     click.echo("software: v{} {}".format(response.software.version, response.software.brand))
     click.echo("plugins: {}".format(response.software.plugins))
-    click.echo("motd: \"{}\"".format(response.motd))
+    click.echo("motd: \"{}\"".format(response.motd.encode("utf-8")))
     click.echo(
         "players: {}/{} {}".format(
             response.players.online,


### PR DESCRIPTION
Ascii doesn't contain "§" character, and it is used to color motd and other text. Sometimes it appears also in version name and player name. `encode("utf-8")` is solution here.

Examples of "§" character usage:  
motd: 
> motd: "    §4h §csomething something"  

version:  
> version: v§cUse version 1.12! (protocol 335)

playername:  
> players: 1/250 ['\xc2\xa7cUse version 1.12+ (00000000-0000-0000-0000-000000000000)']  

(`\xa7` used above is the "§" character)