### PR TITLE
Update connection.py to include ConnectionError

### DIFF
--- a/mcstatus/protocol/connection.py
+++ b/mcstatus/protocol/connection.py
@@ -177,7 +177,10 @@ class UDPSocketConnection(Connection):
     def read(self, length):
         result = bytearray()
         while len(result) == 0:
-            result.extend(self.socket.recvfrom(self.remaining())[0])
+            try:
+                result.extend(self.socket.recvfrom(self.remaining())[0])
+            except socket.timeout:
+                raise ConnectionError
         return result
 
     def write(self, data):


### PR DESCRIPTION
Updates the UDPSocketConnection.read function to raise a ConnectionError when no bytes are received. This would allow the user of the module to handle a socket.timeout exception.