### PR TITLE
Read requirements from file in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-asyncio-dgram==1.2.0
-click==7.1.1
-dnspython3==1.15.0
-six==1.14.0
+asyncio-dgram>=1.2.0
+click>=7.1.1
+dnspython3>=1.15.0
+six>=1.14.0

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,11 @@
 from setuptools import setup
 
-# TODO: read requirements from file
-install_requires = ["click", "dnspython3", "six"]
+with open("requirements.txt") as f:
+    install_requires = f.read().splitlines()
 
-tests_require = ["mock", "nose"]
+with open("test-requirements.txt") as f:
+    tests_require = f.read().splitlines()
+    tests_require.pop(0)  # remove '-r requirements.txt' line
 
 setup(
     name="mcstatus",


### PR DESCRIPTION
Hi,

I noticed the requirements in `requirements.txt` and the install_requires in `setup.py` don't match. This was causing some requirement issues when installing the lastest versions (5.0.0/5.1.0) from PyPI since `asyncio-dgram` is missing from the `setup.py` install_requires.

To fix this, I've changed `setup.py` to read from the requirements files.