### PR TITLE
Rename retries argument in CLI

### DIFF
--- a/mcstatus/scripts/mcstatus.py
+++ b/mcstatus/scripts/mcstatus.py
@@ -84,7 +84,7 @@ def json():
         data['online'] = True
         data['ping'] = ping_res
 
-        status_res = server.status(retries=1)
+        status_res = server.status(tries=1)
         data['version'] = status_res.version.name
         data['protocol'] = status_res.version.protocol
         data['motd'] = status_res.description
@@ -94,7 +94,7 @@ def json():
         if status_res.players.sample is not None:
             data['players'] = [{'name': player.name, 'id': player.id} for player in status_res.players.sample]
 
-        query_res = server.query(retries=1)
+        query_res = server.query(tries=1)
         data['host_ip'] = query_res.raw['hostip']
         data['host_port'] = query_res.raw['hostport']
         data['map'] = query_res.map


### PR DESCRIPTION
Looks like https://github.com/Dinnerbone/mcstatus/pull/89 didn't update the CLI, which still had `retries` passed to the `status` and `query` commands. As a result, `mcstatus <server> json` was just returning `online` and `ping`, without any of the extra data.