### PR TITLE
Fix varint reading and writing. Closes #141

### DIFF
--- a/mcstatus/protocol/connection.py
+++ b/mcstatus/protocol/connection.py
@@ -54,11 +54,13 @@ class Connection:
                 return signed_int32(result).value
         raise IOError("Server sent a varint that was too big!")
 
-    def write_varint(self, value):
+    def write_varint(self, value): 
         remaining = unsigned_int32(value).value
         for i in range(5):
             if remaining & ~0x7F == 0:
                 self.write(struct.pack("!B", remaining))
+                if value > 2 ** 31 - 1:
+                    break
                 return
             self.write(struct.pack("!B", remaining & 0x7F | 0x80))
             remaining >>= 7


### PR DESCRIPTION
Make varint reading and writing functions use C int 32's with ctypes module.
Important: Writing converts value to unsigned_int32, so that signed bit get forced to turn into a part of the number for writing, sort of breaking the number so python handles it like Java and C would. Reading converts final value back to signed_int32 so that the number is correct when python tries to use it.