### PR TITLE
Query protocol fixes

### DIFF
--- a/mcstatus/tests/test_async_querier.py
+++ b/mcstatus/tests/test_async_querier.py
@@ -18,7 +18,8 @@ class TestMinecraftAsyncQuerier:
     def test_handshake(self):
         self.querier.connection.receive(bytearray.fromhex("090000000035373033353037373800"))
         async_decorator(self.querier.handshake)()
-        assert self.querier.connection.flush() == bytearray.fromhex("FEFD090000000000000000")
+        conn_bytes = self.querier.connection.flush()
+        assert conn_bytes[:3] == bytearray.fromhex("FEFD09")
         assert self.querier.challenge == 570350778
 
     def test_query(self):
@@ -28,7 +29,8 @@ class TestMinecraftAsyncQuerier:
             )
         )
         response = async_decorator(self.querier.read_query)()
-        assert self.querier.connection.flush() == bytearray.fromhex("FEFD00000000000000000000000000")
+        conn_bytes = self.querier.connection.flush()
+        assert conn_bytes[:3] == bytearray.fromhex("FEFD00")
         assert response.raw == {
             "hostname": "A Minecraft Server",
             "gametype": "SMP",

--- a/mcstatus/tests/test_async_querier.py
+++ b/mcstatus/tests/test_async_querier.py
@@ -31,6 +31,7 @@ class TestMinecraftAsyncQuerier:
         response = async_decorator(self.querier.read_query)()
         conn_bytes = self.querier.connection.flush()
         assert conn_bytes[:3] == bytearray.fromhex("FEFD00")
+        assert conn_bytes[7:] == bytearray.fromhex("0000000000000000")
         assert response.raw == {
             "hostname": "A Minecraft Server",
             "gametype": "SMP",

--- a/mcstatus/tests/test_querier.py
+++ b/mcstatus/tests/test_querier.py
@@ -23,6 +23,7 @@ class TestMinecraftQuerier:
         response = self.querier.read_query()
         conn_bytes = self.querier.connection.flush()
         assert conn_bytes[:3] == bytearray.fromhex("FEFD00")
+        assert conn_bytes[7:] == bytearray.fromhex("0000000000000000")
         assert response.raw == {
             "hostname": "A Minecraft Server",
             "gametype": "SMP",

--- a/mcstatus/tests/test_querier.py
+++ b/mcstatus/tests/test_querier.py
@@ -9,7 +9,9 @@ class TestMinecraftQuerier:
     def test_handshake(self):
         self.querier.connection.receive(bytearray.fromhex("090000000035373033353037373800"))
         self.querier.handshake()
-        assert self.querier.connection.flush() == bytearray.fromhex("FEFD090000000000000000")
+
+        conn_bytes = self.querier.connection.flush()
+        assert conn_bytes[:3] == bytearray.fromhex("FEFD09")
         assert self.querier.challenge == 570350778
 
     def test_query(self):
@@ -19,7 +21,8 @@ class TestMinecraftQuerier:
             )
         )
         response = self.querier.read_query()
-        assert self.querier.connection.flush() == bytearray.fromhex("FEFD00000000000000000000000000")
+        conn_bytes = self.querier.connection.flush()
+        assert conn_bytes[:3] == bytearray.fromhex("FEFD00")
         assert response.raw == {
             "hostname": "A Minecraft Server",
             "gametype": "SMP",

--- a/mcstatus/tests/test_server.py
+++ b/mcstatus/tests/test_server.py
@@ -139,7 +139,8 @@ class TestMinecraftServer:
             connection.return_value = self.socket
             info = self.server.query()
 
-        assert self.socket.flush() == bytearray.fromhex("FEFD090000000000000000FEFD000000000021FEDCBA00000000")
+        conn_bytes = self.socket.flush()
+        assert conn_bytes[:3] == bytearray.fromhex("FEFD09")
         assert info.raw == {
             "hostname": "A Minecraft Server",
             "gametype": "SMP",

--- a/mcstatus/tests/test_session_id.py
+++ b/mcstatus/tests/test_session_id.py
@@ -1,0 +1,23 @@
+from mock import Mock
+
+from mcstatus.protocol.connection import Connection
+from mcstatus.querier import ServerQuerier
+
+
+class TestHandshake:
+    def setup_method(self):
+        self.querier = ServerQuerier(Connection())
+
+    def test_session_id(self):
+        def session_id():
+            return 0x01010101
+
+        self.querier.connection.receive(bytearray.fromhex("090000000035373033353037373800"))
+        self.querier._generate_session_id = Mock()
+        self.querier._generate_session_id = session_id
+        self.querier.handshake()
+
+        conn_bytes = self.querier.connection.flush()
+        assert conn_bytes[:3] == bytearray.fromhex("FEFD09")
+        assert conn_bytes[3:] == session_id().to_bytes(4, byteorder='big')
+        assert self.querier.challenge == 570350778


### PR DESCRIPTION
This library seems to not conform to minecraft query protocol.

This PR fixes inconsistencies and cleans up query packet handling. Tests are provided.

It now queries PocketMine-MP servers, as well as regular java edition servers.
Closes #145, properly.

Details on fixes (from https://wiki.vg/Query which seems to be the closest to the truth on minecraft protocol):
1. There was an extra zero int written to the handshake packet, now it conforms to this:
![image](https://user-images.githubusercontent.com/3734331/122765001-b81a4480-d2a8-11eb-8a9c-e519d8fab82f.png)

2. Cleaned up request packet generation as well, it all is now handled in one place, rather than doing most of the work in a single method and then adding a padding. It conforms to this:
![image](https://user-images.githubusercontent.com/3734331/122766277-0419b900-d2aa-11eb-87bc-06b227938c98.png)
Functionally not a lot changes.

3. Querier now generates proper session ids instead of always using 0, which helps readability and is more correct.
GameSpot) Query Protocol
![image](https://user-images.githubusercontent.com/3734331/122765726-76d66480-d2a9-11eb-891d-611742c440d1.png)

