### PR TITLE
Update the creation of the description field + minor change to favicon field

### DIFF
--- a/mcstatus/pinger.py
+++ b/mcstatus/pinger.py
@@ -7,6 +7,25 @@ from six import string_types
 
 from mcstatus.protocol.connection import Connection
 
+COLOR_MAP = {
+    "dark_red": "4",
+    "red": "c",
+    "gold": "6",
+    "yellow": "e",
+    "dark_green": "2",
+    "green": "a",
+    "aqua": "b",
+    "dark_aqua": "3",
+    "dark_blue": "1",
+    "blue": "9",
+    "light_purple": "d",
+    "dark_purple": "5",
+    "white": "f",
+    "gray": "7",
+    "dark_gray": "8",
+    "black": "0"
+}
+
 
 class ServerPinger:
     def __init__(
@@ -204,8 +223,35 @@ class PingResponse:
 
         if "description" not in raw:
             raise ValueError("Invalid status object (no 'description' value)")
-        if isinstance(raw["description"], dict):
-            self.description = raw["description"]["text"]
+        if isinstance(raw["description"], (dict, list)):
+            if isinstance(raw["description"], dict):
+                entries = raw["description"].get("extra", ())
+                end = raw["description"]["text"]
+            else:
+                entries = raw["description"]
+                end = ""
+
+            description = ""
+
+            for entry in entries:
+                if entry.get("bold"):
+                    description += "§l"
+
+                if entry.get("italic"):
+                    description += "§o"
+
+                if entry.get("underlined"):
+                    description += "§n"
+
+                if entry.get("obfuscated"):
+                    description += "§k"
+
+                if entry.get("color"):
+                    description += "§" + COLOR_MAP[entry["color"]]
+
+                description += entry.get("text", "")
+
+            self.description = description + end
         else:
             self.description = raw["description"]
 

--- a/mcstatus/pinger.py
+++ b/mcstatus/pinger.py
@@ -255,7 +255,4 @@ class PingResponse:
         else:
             self.description = raw["description"]
 
-        if "favicon" in raw:
-            self.favicon = raw["favicon"]
-        else:
-            self.favicon = None
+        self.favicon = raw.get("favicon")


### PR DESCRIPTION
This PR implements the following (Resolves #147):
- Instead of ignoring formatted text in server MOTDs/descriptions, the code will now stringify the MOTD using Minecraft formatting codes into something like this: `'         §6The §k§4||§l§9CubeCraft§k§4||§f §6Network §a[NA 1.12.2+]\n   §l§c◆§f §l§bNEW 1.12 MAPS§f §l§7+§f §l§eEPIC PARKOUR UPDATE!§f §l§c◆§f'`
- Use `raw.get("favicon")` instead of checking to see if the favicon field exists in the raw data.

I tested this PR on `hypixel.net`, `cubecraft.net`, and `xenon.iapetus11.me` and it worked perfectly.