### PR TITLE
TCPAsyncSocketConnection bugfix

### DIFF
--- a/mcstatus/protocol/connection.py
+++ b/mcstatus/protocol/connection.py
@@ -255,18 +255,20 @@ class UDPSocketConnection(Connection):
 class TCPAsyncSocketConnection(AsyncReadConnection):
     reader = None
     writer = None
+    timeout = None
 
     def __init__(self):
         super().__init__()
 
     async def connect(self, addr, timeout=3):
+        self.timeout = timeout
         conn = asyncio.open_connection(addr[0], addr[1])
-        self.reader, self.writer = await asyncio.wait_for(conn, timeout=timeout)
+        self.reader, self.writer = await asyncio.wait_for(conn, timeout=self.timeout)
 
     async def read(self, length):
         result = bytearray()
         while len(result) < length:
-            new = await self.reader.read(length - len(result))
+            new = await asyncio.wait_for(self.reader.read(length - len(result)), timeout=self.timeout)
             if len(new) == 0:
                 raise IOError("Server did not respond with any information!")
             result.extend(new)

--- a/mcstatus/tests/test_server.py
+++ b/mcstatus/tests/test_server.py
@@ -18,13 +18,11 @@ class MockProtocolFactory(asyncio.Protocol):
 
     def connection_lost(self, exc):
         print("connection_lost")
+        self.transport.close()
 
     def data_received(self, data):
-        try:
-            assert self.data_expected_to_receive in data
-            self.transport.write(self.data_to_respond_with)
-        finally:
-            self.transport.close()
+        assert self.data_expected_to_receive in data
+        self.transport.write(self.data_to_respond_with)
 
     def eof_received(self):
         print("eof_received")

--- a/mcstatus/tests/test_timeout.py
+++ b/mcstatus/tests/test_timeout.py
@@ -1,0 +1,30 @@
+import asyncio
+from asyncio import StreamReader
+
+import pytest
+from mock import patch
+
+from mcstatus.protocol.connection import TCPAsyncSocketConnection
+
+
+class FakeAsyncStream(StreamReader):
+    async def read(self, n: int = ...) -> bytes:
+        await asyncio.sleep(delay=10**3)
+        return bytes([0] * n)
+
+
+def fake_asyncio_asyncio_open_connection(hostname, port):
+    return FakeAsyncStream(), None
+
+
+class TestAsyncSocketConnection:
+    def setup_method(self):
+        self.tcp_async_socket = TCPAsyncSocketConnection()
+
+    def test_tcp_socket_read(self):
+        with patch("asyncio.open_connection") as open_conn:
+            open_conn.return_value = (FakeAsyncStream(), None)
+            asyncio.run(self.tcp_async_socket.connect('dummy_address', timeout=1))
+
+            with pytest.raises(asyncio.exceptions.TimeoutError):
+                asyncio.run(self.tcp_async_socket.read(10))

--- a/mcstatus/tests/test_timeout.py
+++ b/mcstatus/tests/test_timeout.py
@@ -9,7 +9,7 @@ from mcstatus.protocol.connection import TCPAsyncSocketConnection
 
 class FakeAsyncStream(StreamReader):
     async def read(self, n: int = ...) -> bytes:
-        await asyncio.sleep(delay=10**3)
+        await asyncio.sleep(delay=2)
         return bytes([0] * n)
 
 

--- a/mcstatus/tests/test_timeout.py
+++ b/mcstatus/tests/test_timeout.py
@@ -22,9 +22,15 @@ class TestAsyncSocketConnection:
         self.tcp_async_socket = TCPAsyncSocketConnection()
 
     def test_tcp_socket_read(self):
+        try:
+            from asyncio.exceptions import TimeoutError
+        except ImportError:
+            from asyncio import TimeoutError
+
+        loop = asyncio.get_event_loop()
         with patch("asyncio.open_connection") as open_conn:
             open_conn.return_value = (FakeAsyncStream(), None)
-            asyncio.run(self.tcp_async_socket.connect('dummy_address', timeout=1))
+            loop.run_until_complete(self.tcp_async_socket.connect('dummy_address', timeout=0.01))
 
-            with pytest.raises(asyncio.exceptions.TimeoutError):
-                asyncio.run(self.tcp_async_socket.read(10))
+            with pytest.raises(TimeoutError):
+                loop.run_until_complete(self.tcp_async_socket.read(10))


### PR DESCRIPTION
TCPAsyncSocketConnection uses `asyncio.wait_for` wrapper only when connecting.
Now it uses it for reading as well, as per usual, test included.