### PR TITLE
Use f-strings instead of % formatting or str.format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ server = MinecraftServer.lookup("example.org:1234")
 
 # 'status' is supported by all Minecraft servers that are version 1.7 or higher.
 status = server.status()
-print("The server has {0} players and replied in {1} ms".format(status.players.online, status.latency))
+print(f"The server has {status.players.online} players and replied in {status.latency} ms")
 
 # 'ping' is supported by all Minecraft servers that are version 1.7 or higher.
 # It is included in a 'status' call, but is exposed separate if you do not require the additional info.
 latency = server.ping()
-print("The server replied in {0} ms".format(latency))
+print(f"The server replied in {latency} ms")
 
 # 'query' has to be enabled in a servers' server.properties file.
 # It may give more information than a ping, such as a full player list or mod information.
 query = server.query()
-print("The server has the following players online: {0}".format(", ".join(query.players.names)))
+print(f"The server has the following players online: {', '.join(query.players.names)}")
 ```
 
 Command Line Interface

--- a/mcstatus/pinger.py
+++ b/mcstatus/pinger.py
@@ -69,7 +69,7 @@ class ServerPinger:
         try:
             return PingResponse(raw)
         except ValueError as e:
-            raise IOError("Received invalid status response: %s" % e)
+            raise IOError(f"Received invalid status response: {e}")
 
     def test_ping(self):
         request = Connection()
@@ -85,7 +85,7 @@ class ServerPinger:
         received_token = response.read_long()
         if received_token != self.ping_token:
             raise IOError(
-                "Received mangled ping response packet (expected token %d, received %d)" % (self.ping_token, received_token)
+                f"Received mangled ping response packet (expected token {self.ping_token}, received {received_token})"
             )
 
         delta = received - sent
@@ -109,7 +109,7 @@ class AsyncServerPinger(ServerPinger):
         try:
             return PingResponse(raw)
         except ValueError as e:
-            raise IOError("Received invalid status response: %s" % e)
+            raise IOError(f"Received invalid status response: {e}")
 
     async def test_ping(self):
         request = Connection()
@@ -125,7 +125,7 @@ class AsyncServerPinger(ServerPinger):
         received_token = response.read_long()
         if received_token != self.ping_token:
             raise IOError(
-                "Received mangled ping response packet (expected token %d, received %d)" % (self.ping_token, received_token)
+                f"Received mangled ping response packet (expected token {self.ping_token}, received {received_token})"
             )
 
         delta = received - sent
@@ -143,18 +143,18 @@ class PingResponse:
 
             def __init__(self, raw):
                 if not isinstance(raw, dict):
-                    raise ValueError("Invalid player object (expected dict, found %s" % type(raw))
+                    raise ValueError(f"Invalid player object (expected dict, found {type(raw)}")
 
                 if "name" not in raw:
                     raise ValueError("Invalid player object (no 'name' value)")
                 if not isinstance(raw["name"], string_types):
-                    raise ValueError("Invalid player object (expected 'name' to be str, was %s)" % type(raw["name"]))
+                    raise ValueError(f"Invalid player object (expected 'name' to be str, was {type(raw['name'])}")
                 self.name = raw["name"]
 
                 if "id" not in raw:
                     raise ValueError("Invalid player object (no 'id' value)")
                 if not isinstance(raw["id"], string_types):
-                    raise ValueError("Invalid player object (expected 'id' to be str, was %s)" % type(raw["id"]))
+                    raise ValueError(f"Invalid player object (expected 'id' to be str, was {type(raw['id'])}")
                 self.id = raw["id"]
 
         online: int
@@ -163,23 +163,23 @@ class PingResponse:
 
         def __init__(self, raw):
             if not isinstance(raw, dict):
-                raise ValueError("Invalid players object (expected dict, found %s" % type(raw))
+                raise ValueError(f"Invalid players object (expected dict, found {type(raw)}")
 
             if "online" not in raw:
                 raise ValueError("Invalid players object (no 'online' value)")
             if not isinstance(raw["online"], int):
-                raise ValueError("Invalid players object (expected 'online' to be int, was %s)" % type(raw["online"]))
+                raise ValueError(f"Invalid players object (expected 'online' to be int, was {type(raw['online'])})")
             self.online = raw["online"]
 
             if "max" not in raw:
                 raise ValueError("Invalid players object (no 'max' value)")
             if not isinstance(raw["max"], int):
-                raise ValueError("Invalid players object (expected 'max' to be int, was %s)" % type(raw["max"]))
+                raise ValueError(f"Invalid players object (expected 'max' to be int, was {type(raw['max'])}")
             self.max = raw["max"]
 
             if "sample" in raw:
                 if not isinstance(raw["sample"], list):
-                    raise ValueError("Invalid players object (expected 'sample' to be list, was %s)" % type(raw["max"]))
+                    raise ValueError(f"Invalid players object (expected 'sample' to be list, was {type(raw['max'])})")
                 self.sample = [PingResponse.Players.Player(p) for p in raw["sample"]]
             else:
                 self.sample = None
@@ -190,18 +190,18 @@ class PingResponse:
 
         def __init__(self, raw):
             if not isinstance(raw, dict):
-                raise ValueError("Invalid version object (expected dict, found %s" % type(raw))
+                raise ValueError(f"Invalid version object (expected dict, found {type(raw)})")
 
             if "name" not in raw:
                 raise ValueError("Invalid version object (no 'name' value)")
             if not isinstance(raw["name"], string_types):
-                raise ValueError("Invalid version object (expected 'name' to be str, was %s)" % type(raw["name"]))
+                raise ValueError(f"Invalid version object (expected 'name' to be str, was {type(raw['name'])})")
             self.name = raw["name"]
 
             if "protocol" not in raw:
                 raise ValueError("Invalid version object (no 'protocol' value)")
             if not isinstance(raw["protocol"], int):
-                raise ValueError("Invalid version object (expected 'protocol' to be int, was %s)" % type(raw["protocol"]))
+                raise ValueError(f"Invalid version object (expected 'protocol' to be int, was {type(raw['protocol'])})")
             self.protocol = raw["protocol"]
 
     players: Players

--- a/mcstatus/scripts/address_tools.py
+++ b/mcstatus/scripts/address_tools.py
@@ -13,5 +13,5 @@ def ip_type(address):
 def parse_address(address):
     tmp = urlparse("//" + address)
     if not tmp.hostname:
-        raise ValueError("Invalid address '%s'" % address)
+        raise ValueError(f"Invalid address '{address}'")
     return (tmp.hostname, tmp.port)

--- a/mcstatus/scripts/mcstatus.py
+++ b/mcstatus/scripts/mcstatus.py
@@ -49,7 +49,7 @@ def ping():
     """
     Ping server for latency.
     """
-    click.echo("{}ms".format(server.ping()))
+    click.echo(f"{server.ping()}ms")
 
 
 @cli.command(short_help="basic server information")
@@ -59,17 +59,14 @@ def status():
     servers that are version 1.7 or higher.
     """
     response = server.status()
-    click.echo("version: v{} (protocol {})".format(response.version.name, response.version.protocol))
-    click.echo('description: "{}"'.format(response.description))
-    click.echo(
-        "players: {}/{} {}".format(
-            response.players.online,
-            response.players.max,
-            ["{} ({})".format(player.name, player.id) for player in response.players.sample]
-            if response.players.sample is not None
-            else "No players online",
-        )
-    )
+    if response.players.sample is not None:
+        player_sample = str([f"{player.name} ({player.id})" for player in response.players.sample])
+    else:
+        player_sample = "No players online"
+
+    click.echo(f"version: v{response.version.name} (protocol {response.version.protocol})")
+    click.echo(f'description: "{response.description}"')
+    click.echo(f"players: {response.players.online}/{response.players.max} {player_sample}")
 
 
 @cli.command(short_help="all available server information in json")
@@ -121,17 +118,11 @@ def query():
               See https://wiki.vg/Query for further information."""
         )
         raise click.Abort()
-    click.echo("host: {}:{}".format(response.raw["hostip"], response.raw["hostport"]))
-    click.echo("software: v{} {}".format(response.software.version, response.software.brand))
-    click.echo("plugins: {}".format(response.software.plugins))
-    click.echo('motd: "{}"'.format(response.motd))
-    click.echo(
-        "players: {}/{} {}".format(
-            response.players.online,
-            response.players.max,
-            response.players.names,
-        )
-    )
+    click.echo(f"host: {response.raw['hostip']}:{response.raw['hostport']}")
+    click.echo(f"software: v{response.software.version} {response.software.brand}")
+    click.echo(f"plugins: {response.software.plugins}")
+    click.echo(f'motd: "{response.motd}"')
+    click.echo(f"players: {response.players.online}/{response.players.max} {response.players.names}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Since python 3.6, support for "f-strings" was added, this allows us to format strings in a very simple way:
```py
variable = "some value"
foo = f"This string contains {variable}"
```
This is much more readable than using `str.format` or the `%` formatting notation.

I assume the reason these older ways to format strings was to keep the library compatible with older python versions, however at the moment, this library supports >=3.6 which allows us to utilize these f-strings instead of the less readable methods.