### PR TITLE
Add timeout parameter propagation from lookup func

### DIFF
--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -18,19 +18,22 @@ class MinecraftServer:
 
     :param str host: The host/address/ip of the Minecraft server.
     :param int port: The port that the server is on.
+    :param float timeout: The timeout in seconds before failing to connect.
     :attr host:
     :attr port:
     """
 
-    def __init__(self, host: str, port: int = 25565):
+    def __init__(self, host: str, port: int = 25565, timeout: float = 3):
         self.host = host
         self.port = port
+        self.timeout = timeout
 
     @classmethod
-    def lookup(cls, address: str):
+    def lookup(cls, address: str, timeout: float = 3):
         """Parses the given address and checks DNS records for an SRV record that points to the Minecraft server.
 
         :param str address: The address of the Minecraft server, like `example.com:25565`.
+        :param float timeout: The timeout in seconds before failing to connect.
         :return: A `MinecraftServer` instance.
         :rtype: MinecraftServer
         """
@@ -47,7 +50,7 @@ class MinecraftServer:
             except Exception:
                 pass
 
-        return cls(host, port)
+        return cls(host, port, timeout)
 
     def ping(self, tries: int = 3, **kwargs) -> float:
         """Checks the latency between a Minecraft Java Edition server and the client (you).
@@ -58,7 +61,7 @@ class MinecraftServer:
         :rtype: float
         """
 
-        connection = TCPSocketConnection((self.host, self.port))
+        connection = TCPSocketConnection((self.host, self.port), self.timeout)
         exception_to_raise_after_giving_up: Exception
         for _ in range(tries):
             try:
@@ -80,7 +83,7 @@ class MinecraftServer:
         """
 
         connection = TCPAsyncSocketConnection()
-        await connection.connect((self.host, self.port))
+        await connection.connect((self.host, self.port), self.timeout)
         exception_to_raise_after_giving_up: Exception
         for _ in range(tries):
             try:
@@ -102,7 +105,7 @@ class MinecraftServer:
         :rtype: PingResponse
         """
 
-        connection = TCPSocketConnection((self.host, self.port))
+        connection = TCPSocketConnection((self.host, self.port), self.timeout)
         exception_to_raise_after_giving_up: Exception
         for _ in range(tries):
             try:
@@ -126,7 +129,7 @@ class MinecraftServer:
         """
 
         connection = TCPAsyncSocketConnection()
-        await connection.connect((self.host, self.port))
+        await connection.connect((self.host, self.port), self.timeout)
         exception_to_raise_after_giving_up: Exception
         for _ in range(tries):
             try:
@@ -159,7 +162,7 @@ class MinecraftServer:
         exception_to_raise_after_giving_up: Exception
         for _ in range(tries):
             try:
-                connection = UDPSocketConnection((host, self.port))
+                connection = UDPSocketConnection((host, self.port), self.timeout)
                 querier = ServerQuerier(connection)
                 querier.handshake()
                 return querier.read_query()
@@ -188,7 +191,7 @@ class MinecraftServer:
         for _ in range(tries):
             try:
                 connection = UDPAsyncSocketConnection()
-                await connection.connect((host, self.port))
+                await connection.connect((host, self.port), self.timeout)
                 querier = AsyncServerQuerier(connection)
                 await querier.handshake()
                 return await querier.read_query()
@@ -203,13 +206,15 @@ class MinecraftBedrockServer:
 
     :param str host: The host/address/ip of the Minecraft server.
     :param int port: The port that the server is on.
+    :param float timeout: The timeout in seconds before failing to connect.
     :attr host:
     :attr port:
     """
 
-    def __init__(self, host: str, port: int = 19132):
+    def __init__(self, host: str, port: int = 19132, timeout: float = 3):
         self.host = host
         self.port = port
+        self.timeout = timeout
 
     @classmethod
     def lookup(cls, address: str):
@@ -233,7 +238,7 @@ class MinecraftBedrockServer:
 
         for _ in range(tries):
             try:
-                resp = BedrockServerStatus(self.host, self.port, **kwargs).read_status()
+                resp = BedrockServerStatus(self.host, self.port, self.timeout, **kwargs).read_status()
                 break
             except BaseException as e:
                 exception = e
@@ -255,7 +260,7 @@ class MinecraftBedrockServer:
 
         for _ in range(tries):
             try:
-                resp = await BedrockServerStatus(self.host, self.port, **kwargs).read_status_async()
+                resp = await BedrockServerStatus(self.host, self.port, self.timeout, **kwargs).read_status_async()
                 break
             except BaseException as e:
                 exception = e


### PR DESCRIPTION
Closes #173

As mentioned in the issue, the timeout parameter has been added in the lookup functions and propagated to the appropriate functions.

I have done some small functional / visual testing, which are not included. I only tested MinecraftServer since I don't have a BedrockServer and I tested ping, status and query and also the async variants.

During my small functional testing, I observed that if the URL of the server is a domain name, socket.create_connection can take longer than the specified timeout. This is better described here :
https://stackoverflow.com/questions/12232225/python-3-2-3-socket-takes-longer-to-timeout-than-it-should