### PR TITLE
Merge retry logic into a single decorator

### DIFF
--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -8,6 +8,7 @@ from mcstatus.protocol.connection import (
 from mcstatus.querier import QueryResponse, ServerQuerier, AsyncServerQuerier
 from mcstatus.bedrock_status import BedrockServerStatus, BedrockStatusResponse
 from mcstatus.scripts.address_tools import parse_address
+from mcstatus.utils import retry
 import dns.resolver
 
 __all__ = ["MinecraftServer", "MinecraftBedrockServer"]
@@ -52,31 +53,24 @@ class MinecraftServer:
 
         return cls(host, port, timeout)
 
-    def ping(self, tries: int = 3, **kwargs) -> float:
+    @retry(tries=3)
+    def ping(self, **kwargs) -> float:
         """Checks the latency between a Minecraft Java Edition server and the client (you).
 
-        :param int tries: How many times to retry if it fails.
         :param type **kwargs: Passed to a `ServerPinger` instance.
         :return: The latency between the Minecraft Server and you.
         :rtype: float
         """
 
         connection = TCPSocketConnection((self.host, self.port), self.timeout)
-        exception_to_raise_after_giving_up: Exception
-        for _ in range(tries):
-            try:
-                pinger = ServerPinger(connection, host=self.host, port=self.port, **kwargs)
-                pinger.handshake()
-                return pinger.test_ping()
-            except Exception as e:
-                exception_to_raise_after_giving_up = e
-        else:
-            raise exception_to_raise_after_giving_up
+        pinger = ServerPinger(connection, host=self.host, port=self.port, **kwargs)
+        pinger.handshake()
+        return pinger.test_ping()
 
-    async def async_ping(self, tries: int = 3, **kwargs) -> float:
+    @retry(tries=3)
+    async def async_ping(self, **kwargs) -> float:
         """Asynchronously checks the latency between a Minecraft Java Edition server and the client (you).
 
-        :param int tries: How many times to retry if it fails.
         :param type **kwargs: Passed to a `AsyncServerPinger` instance.
         :return: The latency between the Minecraft Server and you.
         :rtype: float
@@ -84,45 +78,31 @@ class MinecraftServer:
 
         connection = TCPAsyncSocketConnection()
         await connection.connect((self.host, self.port), self.timeout)
-        exception_to_raise_after_giving_up: Exception
-        for _ in range(tries):
-            try:
-                pinger = AsyncServerPinger(connection, host=self.host, port=self.port, **kwargs)
-                pinger.handshake()
-                ping = await pinger.test_ping()
-                return ping
-            except Exception as e:
-                exception_to_raise_after_giving_up = e
-        else:
-            raise exception_to_raise_after_giving_up
+        pinger = AsyncServerPinger(connection, host=self.host, port=self.port, **kwargs)
+        pinger.handshake()
+        ping = await pinger.test_ping()
+        return ping
 
-    def status(self, tries: int = 3, **kwargs) -> PingResponse:
+    @retry(tries=3)
+    def status(self, **kwargs) -> PingResponse:
         """Checks the status of a Minecraft Java Edition server via the ping protocol.
 
-        :param int tries: How many times to retry if it fails.
         :param type **kwargs: Passed to a `ServerPinger` instance.
         :return: Status information in a `PingResponse` instance.
         :rtype: PingResponse
         """
 
         connection = TCPSocketConnection((self.host, self.port), self.timeout)
-        exception_to_raise_after_giving_up: Exception
-        for _ in range(tries):
-            try:
-                pinger = ServerPinger(connection, host=self.host, port=self.port, **kwargs)
-                pinger.handshake()
-                result = pinger.read_status()
-                result.latency = pinger.test_ping()
-                return result
-            except Exception as e:
-                exception_to_raise_after_giving_up = e
-        else:
-            raise exception_to_raise_after_giving_up
+        pinger = ServerPinger(connection, host=self.host, port=self.port, **kwargs)
+        pinger.handshake()
+        result = pinger.read_status()
+        result.latency = pinger.test_ping()
+        return result
 
-    async def async_status(self, tries: int = 3, **kwargs) -> PingResponse:
+    @retry(tries=3)
+    async def async_status(self, **kwargs) -> PingResponse:
         """Asynchronously checks the status of a Minecraft Java Edition server via the ping protocol.
 
-        :param int tries: How many times to retry if it fails.
         :param type **kwargs: Passed to a `AsyncServerPinger` instance.
         :return: Status information in a `PingResponse` instance.
         :rtype: PingResponse
@@ -130,23 +110,16 @@ class MinecraftServer:
 
         connection = TCPAsyncSocketConnection()
         await connection.connect((self.host, self.port), self.timeout)
-        exception_to_raise_after_giving_up: Exception
-        for _ in range(tries):
-            try:
-                pinger = AsyncServerPinger(connection, host=self.host, port=self.port, **kwargs)
-                pinger.handshake()
-                result = await pinger.read_status()
-                result.latency = await pinger.test_ping()
-                return result
-            except Exception as e:
-                exception_to_raise_after_giving_up = e
-        else:
-            raise exception_to_raise_after_giving_up
+        pinger = AsyncServerPinger(connection, host=self.host, port=self.port, **kwargs)
+        pinger.handshake()
+        result = await pinger.read_status()
+        result.latency = await pinger.test_ping()
+        return result
 
-    def query(self, tries: int = 3) -> QueryResponse:
+    @retry(tries=3)
+    def query(self) -> QueryResponse:
         """Checks the status of a Minecraft Java Edition server via the query protocol.
 
-        :param int tries: How many times to retry if it fails.
         :return: Query status information in a `QueryResponse` instance.
         :rtype: QueryResponse
         """
@@ -159,22 +132,15 @@ class MinecraftServer:
         except Exception as e:
             pass
 
-        exception_to_raise_after_giving_up: Exception
-        for _ in range(tries):
-            try:
-                connection = UDPSocketConnection((host, self.port), self.timeout)
-                querier = ServerQuerier(connection)
-                querier.handshake()
-                return querier.read_query()
-            except Exception as e:
-                exception_to_raise_after_giving_up = e
-        else:
-            raise exception_to_raise_after_giving_up
+        connection = UDPSocketConnection((host, self.port), self.timeout)
+        querier = ServerQuerier(connection)
+        querier.handshake()
+        return querier.read_query()
 
-    async def async_query(self, tries: int = 3) -> QueryResponse:
+    @retry(tries=3)
+    async def async_query(self) -> QueryResponse:
         """Asynchronously checks the status of a Minecraft Java Edition server via the query protocol.
 
-        :param int tries: How many times to retry if it fails.
         :return: Query status information in a `QueryResponse` instance.
         :rtype: QueryResponse
         """
@@ -187,18 +153,11 @@ class MinecraftServer:
         except Exception as e:
             pass
 
-        exception_to_raise_after_giving_up: BaseException
-        for _ in range(tries):
-            try:
-                connection = UDPAsyncSocketConnection()
-                await connection.connect((host, self.port), self.timeout)
-                querier = AsyncServerQuerier(connection)
-                await querier.handshake()
-                return await querier.read_query()
-            except Exception as e:
-                exception_to_raise_after_giving_up = e
-        else:
-            raise exception_to_raise_after_giving_up
+        connection = UDPAsyncSocketConnection()
+        await connection.connect((host, self.port), self.timeout)
+        querier = AsyncServerQuerier(connection)
+        await querier.handshake()
+        return await querier.read_query()
 
 
 class MinecraftBedrockServer:
@@ -226,46 +185,22 @@ class MinecraftBedrockServer:
         """
         return cls(*parse_address(address))
 
-    def status(self, tries: int = 3, **kwargs) -> BedrockStatusResponse:
+    @retry(tries=3)
+    def status(self, **kwargs) -> BedrockStatusResponse:
         """Checks the status of a Minecraft Bedrock Edition server.
 
-        :param int tries: How many times to retry if it fails.
         :param type **kwargs: Passed to a `BedrockServerStatus` instance.
         :return: Status information in a `BedrockStatusResponse` instance.
         :rtype: BedrockStatusResponse
         """
-        exception = None
+        return BedrockServerStatus(self.host, self.port, self.timeout, **kwargs).read_status()
 
-        for _ in range(tries):
-            try:
-                resp = BedrockServerStatus(self.host, self.port, self.timeout, **kwargs).read_status()
-                break
-            except BaseException as e:
-                exception = e
-
-        if exception:
-            raise exception
-
-        return resp
-
-    async def async_status(self, tries: int = 3, **kwargs) -> BedrockStatusResponse:
+    @retry(tries=3)
+    async def async_status(self, **kwargs) -> BedrockStatusResponse:
         """Asynchronously checks the status of a Minecraft Bedrock Edition server.
 
-        :param int tries: How many times to retry if it fails.
         :param type **kwargs: Passed to a `BedrockServerStatus` instance.
         :return: Status information in a `BedrockStatusResponse` instance.
         :rtype: BedrockStatusResponse
         """
-        exception = None
-
-        for _ in range(tries):
-            try:
-                resp = await BedrockServerStatus(self.host, self.port, self.timeout, **kwargs).read_status_async()
-                break
-            except BaseException as e:
-                exception = e
-
-        if exception:
-            raise exception
-
-        return resp
+        return await BedrockServerStatus(self.host, self.port, self.timeout, **kwargs).read_status_async()

--- a/mcstatus/tests/test_retry_decorator.py
+++ b/mcstatus/tests/test_retry_decorator.py
@@ -1,0 +1,56 @@
+from mcstatus.utils import retry
+from mcstatus.tests.test_async_pinger import async_decorator
+
+
+def test_sync_success():
+    x = -1
+
+    @retry(tries=2)
+    def func():
+        nonlocal x
+        x += 1
+        return 5 / x
+
+    y = func()
+    assert x == 1
+    assert y == 5
+
+
+def test_sync_fail():
+    @retry(tries=2)
+    def func():
+        raise RuntimeError("This will always fail")
+
+    try:
+        func()
+    except Exception as exc:
+        assert isinstance(exc, RuntimeError)
+    else:
+        assert False
+
+
+def test_async_success():
+    x = -1
+
+    @retry(tries=2)
+    async def func():
+        nonlocal x
+        x += 1
+        return 5 / x
+
+    y = async_decorator(func)()
+    assert x == 1
+    assert y == 5
+
+
+def test_async_fail():
+    @retry(tries=2)
+    async def func():
+        raise RuntimeError("This will always fail")
+
+    try:
+        async_decorator(func)()
+    except Exception as exc:
+        assert isinstance(exc, RuntimeError)
+    else:
+        assert False

--- a/mcstatus/tests/test_retry_decorator.py
+++ b/mcstatus/tests/test_retry_decorator.py
@@ -17,13 +17,21 @@ def test_sync_success():
 
 
 def test_sync_fail():
+    x = -1
+
     @retry(tries=2)
     def func():
-        raise RuntimeError("This will always fail")
+        nonlocal x
+        x += 1
+        if x == 0:
+            raise OSError("First error")
+        elif x == 1:
+            raise RuntimeError("Second error")
 
     try:
         func()
     except Exception as exc:
+        # We should always get the last exception on failure
         assert isinstance(exc, RuntimeError)
     else:
         assert False
@@ -44,13 +52,21 @@ def test_async_success():
 
 
 def test_async_fail():
+    x = -1
+
     @retry(tries=2)
     async def func():
-        raise RuntimeError("This will always fail")
+        nonlocal x
+        x += 1
+        if x == 0:
+            raise OSError("First error")
+        elif x == 1:
+            raise RuntimeError("Second error")
 
     try:
         async_decorator(func)()
     except Exception as exc:
+        # We should always get the last exception on failure
         assert isinstance(exc, RuntimeError)
     else:
         assert False

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -3,7 +3,7 @@ from typing import Callable, Tuple, Type
 from functools import wraps
 
 
-def retry(tries: int, exceptions: Tuple[Type[Exception]] = (Exception,)) -> Callable:
+def retry(tries: int, exceptions: Tuple[Type[BaseException]] = (Exception,)) -> Callable:
     """
     Decorator that re-runs given function tries times if error occurs.
 
@@ -19,7 +19,7 @@ def retry(tries: int, exceptions: Tuple[Type[Exception]] = (Exception,)) -> Call
     def decorate(func: Callable) -> Callable:
         @wraps(func)
         async def async_wrapper(*args, tries: int = tries, **kwargs):
-            last_exc: Exception
+            last_exc: BaseException
             for _ in range(tries):
                 try:
                     return await func(*args, **kwargs)
@@ -30,7 +30,7 @@ def retry(tries: int, exceptions: Tuple[Type[Exception]] = (Exception,)) -> Call
 
         @wraps(func)
         def sync_wrapper(*args, tries: int = tries, **kwargs):
-            last_exc: Exception
+            last_exc: BaseException
             for _ in range(tries):
                 try:
                     return func(*args, **kwargs)

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -26,7 +26,7 @@ def retry(tries: int, exceptions: Tuple[Type[Exception]] = (Exception,)) -> Call
                 except exceptions as exc:
                     last_exc = exc
             else:
-                raise last_exc  # type: ignore (This won't actually be unbound)
+                raise last_exc  # type: ignore # (This won't actually be unbound)
 
         @wraps(func)
         def sync_wrapper(*args, tries: int = tries, **kwargs):
@@ -37,7 +37,7 @@ def retry(tries: int, exceptions: Tuple[Type[Exception]] = (Exception,)) -> Call
                 except exceptions as exc:
                     last_exc = exc
             else:
-                raise last_exc  # type: ignore (This won't actually be unbound)
+                raise last_exc  # type: ignore # (This won't actually be unbound)
 
         if asyncio.iscoroutinefunction(func):
             return async_wrapper

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -1,9 +1,9 @@
 import asyncio
-from typing import Callable, Iterable, Type
+from typing import Callable, Tuple, Type
 from functools import wraps
 
 
-def retry(tries: int, exceptions: Iterable[Type[Exception]] = (Exception,)) -> Callable:
+def retry(tries: int, exceptions: Tuple[Type[Exception]] = (Exception,)) -> Callable:
     """
     Decorator that re-runs given function tries times if error occurs.
 

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -1,0 +1,46 @@
+import asyncio
+from typing import Callable, Iterable, Type
+from functools import wraps
+
+
+def retry(tries: int, exceptions: Iterable[Type[Exception]] = (Exception,)) -> Callable:
+    """
+    Decorator that re-runs given function tries times if error occurs.
+
+    The amount of tries will either be the value given to the decorator,
+    or if tries is present in keyword arguments on function call, this
+    specified value will take precedense.
+
+    If the function fails even after all of the retries, raise the last
+    exception that the function raised (even if the previous failures caused
+    a different exception, this will only raise the last one!).
+    """
+
+    def decorate(func: Callable) -> Callable:
+        @wraps(func)
+        async def async_wrapper(*args, tries: int = tries, **kwargs):
+            last_exc: Exception
+            for _ in range(tries):
+                try:
+                    return await func(*args, **kwargs)
+                except exceptions as exc:
+                    last_exc = exc
+            else:
+                raise last_exc  # type: ignore (This won't actually be unbound)
+
+        @wraps(func)
+        def sync_wrapper(*args, tries: int = tries, **kwargs):
+            last_exc: Exception
+            for _ in range(tries):
+                try:
+                    return func(*args, **kwargs)
+                except exceptions as exc:
+                    last_exc = exc
+            else:
+                raise last_exc  # type: ignore (This won't actually be unbound)
+
+        if asyncio.iscoroutinefunction(func):
+            return async_wrapper
+        return sync_wrapper
+
+    return decorate


### PR DESCRIPTION
Closes #139

As discussed in the issue, this introduces a retry decorator which will automate the logic of retrying the code for several specified amount of tries until the function was successful or if the function failed in each of the tries, raise the last exception that occurred.

- [x] Base retry decorator logic
- [x] Convert functions implementing the logic manually to use the decorator
- [x] Pass unittests
- [x] Add tests for the decorator 