### PR TITLE
Ensure the address is valid on server init

### DIFF
--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -20,7 +20,7 @@ def ensure_valid_ip(host: object, port: object):
         raise TypeError(f"Host must be a string address, got {type(host)} ({host!r})")
     if not isinstance(port, int):
         raise TypeError(f"Port must be an integer port number, got {type(port)} ({port})")
-    if port >= 36635 or port < 0:
+    if port > 65535 or port < 0:
         raise ValueError(f"Port must be within the allowed range (0-2^16), got {port}")
     if not re.fullmatch(r"(\w+\.)*\w+", host):
         raise ValueError(f"Invalid host address, {host!r} (doesn't match the required pattern)")

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -22,7 +22,7 @@ def ensure_valid_ip(host: object, port: object):
         raise TypeError(f"Port must be an integer port number, got {type(port)} ({port})")
     if port > 65535 or port < 0:
         raise ValueError(f"Port must be within the allowed range (0-2^16), got {port}")
-    if not re.fullmatch(r"(\w+\.)*\w+", host):
+    if not re.fullmatch(r"(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])", host):
         raise ValueError(f"Invalid host address, {host!r} (doesn't match the required pattern)")
 
 

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -239,7 +239,11 @@ class MinecraftBedrockServer:
         :return: A `MinecraftBedrockServer` instance.
         :rtype: MinecraftBedrockServer
         """
-        return cls(*parse_address(address))
+        host, port = parse_address(address)
+        # If the address didn't contain port, fall back to constructor's default
+        if port is None:
+            return cls(host)
+        return cls(host, port)
 
     def status(self, tries: int = 3, **kwargs) -> BedrockStatusResponse:
         """Checks the status of a Minecraft Bedrock Edition server.

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -1,3 +1,5 @@
+import re
+
 from mcstatus.pinger import PingResponse, ServerPinger, AsyncServerPinger
 from mcstatus.protocol.connection import (
     TCPSocketConnection,
@@ -13,6 +15,17 @@ import dns.resolver
 __all__ = ["MinecraftServer", "MinecraftBedrockServer"]
 
 
+def ensure_valid_ip(host: object, port: object):
+    if not isinstance(host, str):
+        raise TypeError(f"Host must be a string address, got {type(host)} ({host!r})")
+    if not isinstance(port, int):
+        raise TypeError(f"Port must be an integer port number, got {type(port)} ({port})")
+    if port >= 36635 or port < 0:
+        raise ValueError(f"Port must be within the allowed range (0-2^16), got {port}")
+    if not re.fullmatch(r"(\w+\.)*\w+", host):
+        raise ValueError(f"Invalid host address, {host!r} (doesn't match the required pattern)")
+
+
 class MinecraftServer:
     """Base class for a Minecraft Java Edition server.
 
@@ -24,6 +37,7 @@ class MinecraftServer:
     """
 
     def __init__(self, host: str, port: int = 25565, timeout: float = 3):
+        ensure_valid_ip(host, port)
         self.host = host
         self.port = port
         self.timeout = timeout
@@ -212,6 +226,7 @@ class MinecraftBedrockServer:
     """
 
     def __init__(self, host: str, port: int = 19132, timeout: float = 3):
+        ensure_valid_ip(host, port)
         self.host = host
         self.port = port
         self.timeout = timeout


### PR DESCRIPTION
Closes #189 

As shown in the issue, not having any checks for valid values of the server's address can lead to the instance being made without any hint of an error, even though it has unexpected internal values which will be causing issues later. Whenever this happens, since the error will only appear in later usage of this instance, It will not be easy to recognize what's going on. To prevent this, this PR adds a function which simply raises an exception during initialization if the values aren't valid, therefore preventing even the creation of an instance with invalid values.

Note: I've also used regex to ensure that the host address is valid, however I'm not entirely sure if this pattern catches all possible host values correctly, so please make sure to test this before approving the PR.