### PR TITLE
fix motd unicode parse error.

### DIFF
--- a/mcstatus/querier.py
+++ b/mcstatus/querier.py
@@ -133,7 +133,6 @@ class QueryResponse:
         if key == 'hostname':
             response.read_ascii()
             name = bytearray()
-            size = 0
             while True:
                 c = response.read(1)
                 name += c
@@ -141,7 +140,6 @@ class QueryResponse:
                     if response.received[:8].decode('ISO-8859-1') == 'gametype':
                         name.pop()
                         break
-                size += 1
             # Since the minecraft protocol does not support unicode, the hostname is still not resolved correctly
             # However, this will avoid other parameter parsing errors
             data[key] = name.decode('ISO-8859-1')

--- a/mcstatus/querier.py
+++ b/mcstatus/querier.py
@@ -128,6 +128,24 @@ class QueryResponse:
         data = {}
         players = []
 
+        # If hostname is set to unicode, using other parameters of read_ascii() may be in the wrong order
+        key = response.received[:8].decode('ISO-8859-1')
+        if key == 'hostname':
+            response.read_ascii()
+            name = bytearray()
+            size = 0
+            while True:
+                c = response.read(1)
+                name += c
+                if c[0] == 0:
+                    if response.received[:8].decode('ISO-8859-1') == 'gametype':
+                        name.pop()
+                        break
+                size += 1
+            # Since the minecraft protocol does not support unicode, the hostname is still not resolved correctly
+            # However, this will avoid other parameter parsing errors
+            data[key] = name.decode('ISO-8859-1')
+
         while True:
             key = response.read_ascii()
             if len(key) == 0:

--- a/mcstatus/tests/test_querier.py
+++ b/mcstatus/tests/test_querier.py
@@ -47,6 +47,8 @@ class TestMinecraftQuerier:
         response = self.querier.read_query()
         conn_bytes = self.querier.connection.flush()
         
+        assert response.motd == b'\x00*K\xc3\x95'.decode()
+        # Make sure the order is correct
         assert response.raw['game_id'] == 'MINECRAFT'
 
     def test_query_handles_unicode_motd_with_2a00_at_the_start(self):
@@ -57,7 +59,9 @@ class TestMinecraftQuerier:
         )
         response = self.querier.read_query()
         conn_bytes = self.querier.connection.flush()
-
+        
+        assert response.motd == "\x00other"
+        # Make sure the order is correct
         assert response.raw['game_id'] == 'MINECRAFT'
 
 

--- a/mcstatus/tests/test_querier.py
+++ b/mcstatus/tests/test_querier.py
@@ -50,6 +50,7 @@ class TestMinecraftQuerier:
         assert response.motd == b'\x00*K\xc3\x95'.decode()
         # Make sure the order is correct
         assert response.raw['game_id'] == 'MINECRAFT'
+        assert response.motd == "\x00*KÕ"
 
     def test_query_handles_unicode_motd_with_2a00_at_the_start(self):
         self.querier.connection.receive(

--- a/mcstatus/tests/test_querier.py
+++ b/mcstatus/tests/test_querier.py
@@ -46,9 +46,7 @@ class TestMinecraftQuerier:
         )
         response = self.querier.read_query()
         conn_bytes = self.querier.connection.flush()
-        
-        assert response.motd == b'\x00*K\xc3\x95'.decode()
-        # Make sure the order is correct
+
         assert response.raw['game_id'] == 'MINECRAFT'
         assert response.motd == "\x00*KÕ"
 
@@ -60,9 +58,7 @@ class TestMinecraftQuerier:
         )
         response = self.querier.read_query()
         conn_bytes = self.querier.connection.flush()
-        
-        assert response.motd == "\x00other"
-        # Make sure the order is correct
+
         assert response.raw["game_id"] == "MINECRAFT"
         assert response.motd == "\x00other"  # "\u2a00other" is actually what is expected,
         # but the query protocol for vanilla has a bug when it comes to unicode handling.

--- a/mcstatus/tests/test_querier.py
+++ b/mcstatus/tests/test_querier.py
@@ -38,6 +38,28 @@ class TestMinecraftQuerier:
         }
         assert response.players.names == ["Dinnerbone", "Djinnibone", "Steve"]
 
+    def test_query_handles_unicode_motd_with_nulls(self):
+        self.querier.connection.receive(
+            bytearray(
+                b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00hostname\x00\x00*K\xd5\x00gametype\x00SMP\x00game_id\x00MINECRAFT\x00version\x001.16.5\x00plugins\x00Paper on 1.16.5-R0.1-SNAPSHOT\x00map\x00world\x00numplayers\x000\x00maxplayers\x0020\x00hostport\x0025565\x00hostip\x00127.0.1.1\x00\x00\x01player_\x00\x00\x00"
+            )
+        )
+        response = self.querier.read_query()
+        conn_bytes = self.querier.connection.flush()
+        
+        assert response.raw['game_id'] == 'MINECRAFT'
+
+    def test_query_handles_unicode_motd_with_2a00_at_the_start(self):
+        self.querier.connection.receive(
+            bytearray.fromhex(
+                "00000000000000000000000000000000686f73746e616d6500006f746865720067616d657479706500534d500067616d655f6964004d494e4543524146540076657273696f6e00312e31382e3100706c7567696e7300006d617000776f726c64006e756d706c61796572730030006d6178706c617965727300323000686f7374706f727400323535363500686f73746970003137322e31372e302e32000001706c617965725f000000"
+            )
+        )
+        response = self.querier.read_query()
+        conn_bytes = self.querier.connection.flush()
+
+        assert response.raw['game_id'] == 'MINECRAFT'
+
 
 class TestQueryResponse:
     def setup_method(self):

--- a/mcstatus/tests/test_querier.py
+++ b/mcstatus/tests/test_querier.py
@@ -63,7 +63,10 @@ class TestMinecraftQuerier:
         
         assert response.motd == "\x00other"
         # Make sure the order is correct
-        assert response.raw['game_id'] == 'MINECRAFT'
+        assert response.raw["game_id"] == "MINECRAFT"
+        assert response.motd == "\x00other"  # "\u2a00other" is actually what is expected,
+        # but the query protocol for vanilla has a bug when it comes to unicode handling.
+        # The status protocol correctly shows "⨀other".
 
 
 class TestQueryResponse:


### PR DESCRIPTION
If `motd` set to unicode in `server.properties` , using other parameters of `read_ascii()` may be in the wrong order. (0x00 not unicode end)

![1642402315(1)](https://user-images.githubusercontent.com/35518985/149721361-1031401a-6f2a-4c14-bf4d-fd4916afb413.png)

Since the minecraft protocol does not support unicode, the hostname is still not resolved correctly.
However, this will avoid other parameter parsing errors.