### PR TITLE
Annotate alternative constructors with Self

### DIFF
--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -1,4 +1,5 @@
 import re
+from typing_extensions import Self
 
 from mcstatus.pinger import PingResponse, ServerPinger, AsyncServerPinger
 from mcstatus.protocol.connection import (
@@ -49,7 +50,7 @@ class MinecraftServer:
         self.timeout = timeout
 
     @classmethod
-    def lookup(cls, address: str, timeout: float = 3):
+    def lookup(cls, address: str, timeout: float = 3) -> Self:
         """Parses the given address and checks DNS records for an SRV record that points to the Minecraft server.
 
         :param str address: The address of the Minecraft server, like `example.com:25565`.
@@ -214,7 +215,7 @@ class MinecraftBedrockServer:
         self.timeout = timeout
 
     @classmethod
-    def lookup(cls, address: str):
+    def lookup(cls, address: str) -> Self:
         """Parses a given address and returns a MinecraftBedrockServer instance.
 
         :param str address: The address of the Minecraft server, like `example.com:19132`


### PR DESCRIPTION
After an [approval from discord](https://discord.com/channels/936788458939224094/936788458939224097/938273648316416001), this PR uses the recently added `Self` type annotation from [PEP 673](https://www.python.org/dev/peps/pep-0673/), scheduled to be added into python in 3.11 to annotate alternative constructors easily without having to make individual type variables for each class that needs them just to support subclassing.

Even though this type annotation isn't yet in python's standard library, the `typing_extensions` package does already contain it and pyright type checker does already full support it.

- [x] Blocked by #199 