### PR TITLE
Link to PyPI repo from the badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![travis build status](https://img.shields.io/travis/Dinnerbone/mcstatus/master.svg)
-![current version](https://img.shields.io/pypi/v/mcstatus.svg)
+[![current PyPI version](https://img.shields.io/pypi/v/mcstatus.svg)](https://pypi.org/project/mcstatus/)
 ![supported python versions](https://img.shields.io/pypi/pyversions/mcstatus.svg)
 [![discord chat](https://img.shields.io/discord/936788458939224094.svg?logo=Discord)](https://discord.gg/C2wX7zduxC)
 


### PR DESCRIPTION
Originally, when clicking on the PyPI badge in README, it redirected you to an image of that badge. This changes this behavior to instead redirect to the PyPI mcstatus repository, making it a lot more convenient.