### PR TITLE
Remove MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include requirements.txt
-include test-requirements.txt


### PR DESCRIPTION
This file is no longer necessary due to the use of Poetry and consequently `pyproject.toml`.
This change was [discussed in the Discord server](https://canary.discord.com/channels/936788458939224094/936788458939224097/940395422101430302).