### PR TITLE
Cancel workflow if a new one is already running

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -2,6 +2,10 @@ name: Tox test
 
 on: [pull_request, push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # Make sure pip caches dependencies and installs as user
   PIP_NO_CACHE_DIR: false

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -2,6 +2,10 @@ name: Validation
 
 on: [pull_request, push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # Make sure pip caches dependencies and installs as user
   PIP_NO_CACHE_DIR: false


### PR DESCRIPTION
This is an optimization which automatically cancels older workflows which are in progress if there's a new one that's already running. This can happen if someone pushes before the first workflows even finished, in which case we don't need to finish the previous running workflows, as we only ever care about the last commit passing, not all commits.