### PR TITLE
Rename server classes

### DIFF
--- a/mcstatus/__init__.py
+++ b/mcstatus/__init__.py
@@ -1,1 +1,1 @@
-from mcstatus.server import BedrockServer, JavaServer  # noqa: F401
+from mcstatus.server import BedrockServer, JavaServer, MinecraftBedrockServer, MinecraftServer  # noqa: F401

--- a/mcstatus/__init__.py
+++ b/mcstatus/__init__.py
@@ -1,1 +1,1 @@
-from mcstatus.server import MinecraftBedrockServer, MinecraftServer  # noqa: F401
+from mcstatus.server import BedrockServer, JavaServer  # noqa: F401

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from typing import Optional, TYPE_CHECKING, Tuple
 from urllib.parse import urlparse
 
@@ -16,7 +15,7 @@ from mcstatus.protocol.connection import (
     UDPSocketConnection,
 )
 from mcstatus.querier import AsyncServerQuerier, QueryResponse, ServerQuerier
-from mcstatus.utils import retry
+from mcstatus.utils import deprecated, retry
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -257,6 +256,7 @@ class BedrockServer:
         return await BedrockServerStatus(self.host, self.port, self.timeout, **kwargs).read_status_async()
 
 
+@deprecated(replacement="JavaServer")
 class MinecraftServer(JavaServer):
     """This is a deprecated version of the base class for a Java Minecraft Server.
 
@@ -264,9 +264,9 @@ class MinecraftServer(JavaServer):
     """
     def __init__(self, host: str, port: int = 25565, timeout: float = 3):
         super().__init__(host, port=port, timeout=timeout)
-        warnings.warn("'MinecraftServer' is deprecated and will be removed, use 'JavaServer' instead")
 
 
+@deprecated(replacement="BedrockServer")
 class MinecraftBedrockServer(BedrockServer):
     """This is a deprecated version of the base class for a Bedrock Minecraft Server.
 
@@ -274,4 +274,3 @@ class MinecraftBedrockServer(BedrockServer):
     """
     def __init__(self, host: str, port: int = 19139, timeout: float = 3):
         super().__init__(host, port=port, timeout=timeout)
-        warnings.warn("'MinecraftBedrockServer' is deprecated and will be removed in, use 'BedrockServer' instead")

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
 
-__all__ = ["MinecraftServer", "MinecraftBedrockServer"]
+__all__ = ["JavaServer", "BedrockServer"]
 
 
 def parse_address(address: str) -> Tuple[str, Optional[int]]:
@@ -40,7 +40,7 @@ def ensure_valid(host: object, port: object):
         raise ValueError(f"Port must be within the allowed range (0-2^16), got {port}")
 
 
-class MinecraftServer:
+class JavaServer:
     """Base class for a Minecraft Java Edition server.
 
     :param str host: The host/address/ip of the Minecraft server.
@@ -205,7 +205,7 @@ class MinecraftServer:
         return await querier.read_query()
 
 
-class MinecraftBedrockServer:
+class BedrockServer:
     """Base class for a Minecraft Bedrock Edition server.
 
     :param str host: The host/address/ip of the Minecraft server.
@@ -254,3 +254,4 @@ class MinecraftBedrockServer:
         :rtype: BedrockStatusResponse
         """
         return await BedrockServerStatus(self.host, self.port, self.timeout, **kwargs).read_status_async()
+

--- a/mcstatus/server.py
+++ b/mcstatus/server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Optional, TYPE_CHECKING, Tuple
 from urllib.parse import urlparse
 
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
 
-__all__ = ["JavaServer", "BedrockServer"]
+__all__ = ["JavaServer", "BedrockServer", "MinecraftServer", "MinecraftBedrockServer"]
 
 
 def parse_address(address: str) -> Tuple[str, Optional[int]]:
@@ -255,3 +256,22 @@ class BedrockServer:
         """
         return await BedrockServerStatus(self.host, self.port, self.timeout, **kwargs).read_status_async()
 
+
+class MinecraftServer(JavaServer):
+    """This is a deprecated version of the base class for a Java Minecraft Server.
+
+    This class is kept purely for backwards compatibility reasons and will be removed eventually.
+    """
+    def __init__(self, host: str, port: int = 25565, timeout: float = 3):
+        super().__init__(host, port=port, timeout=timeout)
+        warnings.warn("'MinecraftServer' is deprecated and will be removed, use 'JavaServer' instead")
+
+
+class MinecraftBedrockServer(BedrockServer):
+    """This is a deprecated version of the base class for a Bedrock Minecraft Server.
+
+    This class is kept purely for backwards compatibility reasons and will be removed eventually.
+    """
+    def __init__(self, host: str, port: int = 19139, timeout: float = 3):
+        super().__init__(host, port=port, timeout=timeout)
+        warnings.warn("'MinecraftBedrockServer' is deprecated and will be removed in, use 'BedrockServer' instead")

--- a/mcstatus/utils.py
+++ b/mcstatus/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import warnings
 from functools import wraps
 from typing import Callable, Tuple, Type
 
@@ -40,6 +41,36 @@ def retry(tries: int, exceptions: Tuple[Type[BaseException]] = (Exception,)) -> 
                     last_exc = exc
             else:
                 raise last_exc  # type: ignore # (This won't actually be unbound)
+
+        if asyncio.iscoroutinefunction(func):
+            return async_wrapper
+        return sync_wrapper
+
+    return decorate
+
+
+def deprecated(replacement: str = None, version: str = None, msg: str = None):
+    def decorate(func: Callable) -> Callable:
+        # Construct and send the warning message
+        name = getattr(func, "__qualname__", func.__name__)
+        warn_message = f"'{name}' is deprecated and will be removed"
+        if version is not None:
+            warn_message += f" in {version}"
+        if replacement is not None:
+            warn_message += f", use '{replacement}' instead"
+        warn_message += "."
+        if msg is not None:
+            warn_message += f" ({msg})"
+
+        @wraps(func)
+        def sync_wrapper(*args, **kwargs):
+            warnings.warn(warn_message)
+            return func(*args, **kwargs)
+
+        @wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            warnings.warn(warn_message)
+            return await func(*args, **kwargs)
 
         if asyncio.iscoroutinefunction(func):
             return async_wrapper


### PR DESCRIPTION
As was already [discussed on the discord server](https://discord.com/channels/936788458939224094/936788458939224097/938236414716428308), we decided that it would be a good idea to rename `MinecraftServer` to `JavaServer` instead, since the reason for naming it `MinecraftServer` was purely because this library was made before bedrock edition even existed so there was no confusion, however now, that's not the case anymore and it's very odd to have `MinecraftServer` and `MinecraftBedrockServer` classes, with `MinecraftServer` being used for the java version.

This also drops the `Minecraft` prefix from these classes (`MinecraftBedrockServer` becomes `BedrockServer`) since we've decided that there's no point in keeping it either as in most cases, it will be obvious what these names are referring to, and if there was a conflict somewhere, people can always use an import as statement (`from mcstatus import JavaServer as MinecraftJavaServer`)

To preserve backwards compatibility, I've added simple classes which inherit from these new ones, having the original names. These classes will produce deprecation warnings if used.